### PR TITLE
refactor: use set_ instead of on_ for setting traits from the frontend

### DIFF
--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -188,6 +188,11 @@ export class ReactView extends DOMWidgetView {
       for (const key of Object.keys(this.model.attributes)) {
         props[key] = this.model.get(key);
         props["on_" + key] = (value: any) => {
+          console.warn(`on_${key} is deprecated, use set_${key} instead`);
+          this.model.set(key, value);
+          this.touch();
+        };
+        props["set_" + key] = (value: any) => {
           this.model.set(key, value);
           this.touch();
         };

--- a/tests/ui/library_test.py
+++ b/tests/ui/library_test.py
@@ -7,8 +7,8 @@ code = \
 import Button from '@mui/material/Button';
 import * as React from "react"; 
 
-export default function({value, on_value, debug}) {
-    return <Button variant="contained" onClick={() => on_value(value + 1)}>
+export default function({value, set_value, debug}) {
+    return <Button variant="contained" onClick={() => set_value(value + 1)}>
         {value || 0} times
     </Button>
 };

--- a/tests/unit/create_test.py
+++ b/tests/unit/create_test.py
@@ -5,8 +5,8 @@ def test_create():
         _esm = """
         import * as React from "react";
 
-        export default function({value, on_value, debug}) {
-            return <button class="confetti-widget" onClick={() => on_value(value + 1)}>
+        export default function({value, set_value, debug}) {
+            return <button class="confetti-widget" onClick={() => set_value(value + 1)}>
                 {value || 0} clicks
             </button>
         };"""


### PR DESCRIPTION
TODO:
  - [ ] change examples, and document that `set_` should be used and `on_..` is deprecated.