### PR TITLE
readme: add yarn install instructions to dev install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ conda create -n ipyreact-dev -c conda-forge nodejs yarn python jupyterlab
 conda activate ipyreact-dev
 ```
 
+Install the JS dependencies.
+```
+yarn install
+```
+
 Install the python. This will also build the TS package.
 ```bash
 pip install -e ".[test, examples]"


### PR DESCRIPTION
When running the `pip install .[...]` install instruction, it fails with an error:
```
      > yarn run build:lib && yarn run build:nbextension && yarn run build:labextension

      Internal Error: @widgetti/jupyter-react@workspace:.: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile
```

This is fixable if you just yarn install before running the `pip install` command.