### PR TITLE
JupyterLite-Part5

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Build on top of [AnyWidget](https://anywidget.dev/).
 
  This tutorial will walk you through the steps of building a complete ipywidget with react. 
 
-[![JupyterLight](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://widgetti.github.io/ipyreact/)
+[![JupyterLight](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://widgetti.github.io/ipyreact/lab/?path=full_tutorial.ipynb)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/widgetti/ipyreact/HEAD?labpath=examples%2Ffull_tutorial.ipynb)
 
 

--- a/lab/jupyter-lite.json
+++ b/lab/jupyter-lite.json
@@ -1,0 +1,7 @@
+{
+  "jupyter-config-data": {
+    "enableMemoryStorage": true,
+    "settingsStorageDrivers": ["memoryStorageDriver"],
+    "contentsStorageDrivers": ["memoryStorageDriver"]
+  }
+}


### PR DESCRIPTION
This setting will prevent JupyterLite from caching content, as discussed in:
https://github.com/jupyterlite/jupyterlite/issues/1067#issuecomment-1550405195
Benefit:
Users will always see the latest JupyterLite content, and closing the JupyterLite website will discard all changes. 