### PR TITLE
fix: Replace missing file with basic React template

### DIFF
--- a/ipyreact/basic.tsx
+++ b/ipyreact/basic.tsx
@@ -1,0 +1,10 @@
+import Button from '@mui/material/Button';
+import confetti from "canvas-confetti";
+
+import * as React from "react";
+export default function({value, on_value, debug}) {
+    if(debug) {
+        console.log("value=", value, on_value);
+    }
+    return <Button variant="contained" onClick={() => confetti() && on_value(value + 1)}>{value || 0} times confetti</Button>
+};

--- a/ipyreact/widget.py
+++ b/ipyreact/widget.py
@@ -44,13 +44,7 @@ class ReactWidget(anywidget.AnyWidget):
         "scopes": {
         },
     }
-    _esm = """
-    import * as React from "react";
-
-    export default function App() {
-        <p>Welcome to ipyreact!</p>
-    }
-    """
+    _esm = HERE / Path("basic.tsx")
 
     def __init__(self, **kwargs) -> None:
         _import_map = kwargs.pop("_import_map", {})

--- a/ipyreact/widget.py
+++ b/ipyreact/widget.py
@@ -44,7 +44,13 @@ class ReactWidget(anywidget.AnyWidget):
         "scopes": {
         },
     }
-    _esm = HERE / Path("basic.tsx")
+    _esm = """
+    import * as React from "react";
+
+    export default function App() {
+        <p>Welcome to ipyreact!</p>
+    }
+    """
 
     def __init__(self, **kwargs) -> None:
         _import_map = kwargs.pop("_import_map", {})


### PR DESCRIPTION
Fixes #46. There is no `basic.tsx` file, which with 0.7.1 throws a Python error rather than silently failing in the frontend.
