### PR TITLE
fix: support buffers/DataView in props

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,11 @@ the `install` command every time that you rebuild your extension. For certain in
 you might also need another flag instead of `--sys-prefix`, but we won't cover the meaning
 of those flags here.
 
+## Binary data transport
+
+Binary data such as NumPy arrays, or Arrow data can be efficiently transported to the frontend.
+Props support object that support the buffer interface. See [this test as an example](https://github.com/widgetti/ipyreact/tree/master/tests/ui/serialize_test.py).
+
 ### How to see your changes
 
 #### Typescript:

--- a/tests/ui/serialize_test.py
+++ b/tests/ui/serialize_test.py
@@ -1,0 +1,27 @@
+import numpy as np
+import playwright.sync_api
+from IPython.display import display
+
+import ipyreact
+
+code = """
+import {Button} from '@mui/material';
+import * as React from "react";
+
+export default function({floatArrayDataView}) {
+    const floatArray = new Float32Array(floatArrayDataView.buffer);
+    console.log({floatArray, floatArrayDataView});
+    return <div>{`v:${floatArray[0]}`}</div>
+};
+"""
+
+
+def test_material_ui(solara_test, assert_solara_snapshot, page_session: playwright.sync_api.Page):
+    class SerializeTest(ipyreact.ReactWidget):
+        _esm = code
+
+    ar = np.array([42.0], dtype=np.float32)
+    b = SerializeTest(props={"floatArrayDataView": memoryview(ar)})
+    display(b)
+
+    page_session.locator("text=42").wait_for()


### PR DESCRIPTION
This allows us to send numpy arrays efficiently.
Before, a buffer (from the Python side) was transformed into a empty object, now it is a DataView object.