### PR TITLE
fix: throw when creating components

### DIFF
--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -592,29 +592,21 @@ export class ReactModel extends DOMWidgetModel {
         );
         module = await importShim(this.codeUrl);
         if (!module) {
-          return () => <div>error loading module</div>;
+          throw new Error(`Error loading module`);
         }
       } else {
         module = await importShim(moduleName);
         if (!module) {
-          return () => <div>no module found with name {moduleName}</div>;
+          throw new Error(`no module found with name ${moduleName}`);
         }
       }
       let component = module[type || "default"];
       if (!component) {
         if (type) {
-          return () => (
-            <div>
-              no component found in module {moduleName} (with name {type})
-            </div>
-          );
+          throw new Error(`no component ${type} found in module ${moduleName}`);
         } else {
-          return () => (
-            <div>
-              no component found in module {moduleName} (it should be exported
-              as default)
-            </div>
-          );
+          throw new Error(`
+            no component found in module ${moduleName} (it should be exported as default)`);
         }
       } else {
         if (this.compiledCode) {


### PR DESCRIPTION
Previously we rendered a div with the error inside. However, this causes issues in contexts where a div can't be rendered, for example if we're inside a three.js `Canvas`.

TODO:
- [ ] verify that the error messages aren't suppressed in other contexts